### PR TITLE
SEO-193848-ug-xamarin-title-too-long

### DIFF
--- a/Xamarin/Licensing/licensing-faq/CI-license-validation.md
+++ b/Xamarin/Licensing/licensing-faq/CI-license-validation.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: License Validation in CI Services - Syncfusion®
+title: License Validation in CI Services | Syncfusion®
 description: Learn here about how to register Syncfusion® license key for Syncfusion® application for license validation.
 platform: xamarin
 control: Essential Studio<sup>®</sup>


### PR DESCRIPTION
Hi @MallikaRK ,

|Title|Description|
|--|--|
|Task Category| Title too long|
|Content Task Link/Mail Screenshot|https://syncfusion-content.bolddesk.com/support/tickets/2857|
|UX task| NA|
|Hotfix PR|https://github.com/syncfusion-content/xamarin-docs/pull/1053 |
|Ticket/Task link|https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/196039/|
|Excel/SharePoint link||

Changes Made | Reason for change |
-- | -- |
|Modified meta elements| To update meta alignment in 20-70 characters|
section|
Regards,
Edith.