### PR TITLE
932495-[Hotfix] Xamarin ImageEditor unwanted link removed

### DIFF
--- a/Xamarin/Image-Editor/Serialization.md
+++ b/Xamarin/Image-Editor/Serialization.md
@@ -47,8 +47,6 @@ The SaveEdits() method is used to serialize the current edits of shapes. The ser
 
 You can save stream into .txt format file. If you save stream as .txt format file to deserialize the shapes, then set the Build action to `Embedded resource` in project.
 
-Sample text file: [ImageEditor.txt](https://s3.amazonaws.com/files2.syncfusion.com/dtsupport/directtrac/general/txt/Chart677841499.txt?AWSAccessKeyId=AKIAWH6GYCX3TZ4I4YVB&Expires=1695709055&Signature=9L6xHfsas4aolVJk5ps3IkVEdBk%3D).
-
 ## Deserialization
 
 The LoadEdits() method is used to deserialize the edits over an image.

--- a/Xamarin/Image-Editor/Serialization.md
+++ b/Xamarin/Image-Editor/Serialization.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Serialization in Xamarin Image Editor control | Syncfusion<sup>&reg;</sup>
-description: Learn here all about Serialization support in Syncfusion<sup>&reg;</sup> Xamarin Image Editor (SfImageEditor) control and more.
+title: Serialization in Xamarin Image Editor control | Syncfusion®
+description: Learn here all about Serialization support in Syncfusion® Xamarin Image Editor (SfImageEditor) control and more.
 platform: xamarin
 control: ImageEditor
 documentation: ug


### PR DESCRIPTION
### Description ###
Xamarin unwanted link removed in ImageEditor UG on Serialization topic.