### PR TITLE
201866-Site-Audit-SERPSTAT-Issue-Title-too-Long-Xamarin-licencing

### DIFF
--- a/Xamarin/Licensing/licensing-faq/CI-license-validation.md
+++ b/Xamarin/Licensing/licensing-faq/CI-license-validation.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Overview of Syncfusion® license validation in CI services - Syncfusion®
+title: Overview of license validation in CI services | Syncfusion
 description: Learn here about how to register Syncfusion® license key for Syncfusion® application for license validation.
 platform: xamarin
 control: Essential Studio<sup>®</sup>


### PR DESCRIPTION
Hi @MallikaRK 

|Title|Description|
|--|--|
|Task Category|Site Audir- SERPSTAT Issue fixes-Title too long
|Content Task Link/Mail Screenshot|![image](https://github.com/user-attachments/assets/ff6fc063-f31a-4787-adeb-f2afe9275366)![image](https://github.com/user-attachments/assets/3d5d8745-2bfe-42e8-a15a-26eb516ef8bd)|
|UX task| NA|
|Hotfix|https://github.com/syncfusion-content/xamarin-docs/pull/1103
|Ticket/Task link|https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/201866/
|Excel/SharePoint link| NA|https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7B8D09F47E-B62B-44E2-8EFE-FF4F4B48899B%7D&file=Page%20with%20redirect.xlsx&nav=MTVfezAwMDAwMDAwLTAwMDEtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMH0&wdOrigin=TEAMS-MAGLEV.p2p_ns.rwc&action=default&mobileredirect=true
|Changes made|Reason for changes|
|--|--|
|Title too long| According to SEO the title character counts should not be below 20 and should exceed 70
 
Regards,
Mercy A.